### PR TITLE
Fix DAV path and missing PHP XML

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ FROM smebberson/alpine-base
 RUN apk add --no-cache apache2 apache2-utils apache2-webdav mod_dav_svn &&\
 	apk add --no-cache subversion &&\
 	apk add --no-cache wget unzip php7 php7-apache2 php7-session php7-json &&\
+	apk add --no-cache php7-xml &&\	
 	mkdir -p /run/apache2/ &&\
 	mkdir /home/svn/ &&\
 	mkdir /etc/subversion &&\

--- a/dav_svn.conf
+++ b/dav_svn.conf
@@ -8,6 +8,6 @@ LoadModule authz_svn_module /usr/lib/apache2/mod_authz_svn.so
      AuthType Basic
      AuthName "Subversion Repository"
      AuthUserFile /etc/subversion/passwd
-     AuthzSVNAccessFile /etc/subversion/svn-access-control
+     AuthzSVNAccessFile /etc/subversion/subversion-access-control
      Require valid-user
   </Location>


### PR DESCRIPTION
- The path to the authentication file in dav-conf did not match the location used in the Dockerfile
-- Made dav-conf use location specified in Dockerfile 
- the GUI admin failed on listing repos; needed xmlwriter from php7-xml
-- added php7-xml to apks in Dockerfile