### PR TITLE
Fixed apache pid already running error when container was restarted

### DIFF
--- a/apache/run
+++ b/apache/run
@@ -2,4 +2,7 @@
 
 # From https://github.com/smebberson/docker-alpine/tree/master/alpine-apache
 
+# avoid 'already pid is running' error
+rm -f /run/apache2/httpd.pid
+
 exec /usr/sbin/apachectl -DFOREGROUND;


### PR DESCRIPTION
I used this image well in my synology nas.
But there is one error when container was restarted so I add one line to remove httpd pid file.
After container has been restarted well.

Docker Logs
![image](https://user-images.githubusercontent.com/936592/71335473-31d35400-2586-11ea-983b-a50ee76138cd.png)
