### PR TITLE
Adds support for https

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Alpine Linux with s6 service management
-FROM smebberson/alpine-base:3.2.0
+FROM smebberson/alpine-base:3.3.0
 
 	# Install Apache2 and other stuff needed to access svn via WebDav
 	# Install svn
@@ -7,7 +7,7 @@ FROM smebberson/alpine-base:3.2.0
 	# Create required folders
 	# Create the authentication file for http access
 	# Getting SVNADMIN interface
-RUN apk add --no-cache apache2 apache2-utils apache2-webdav mod_dav_svn &&\
+RUN apk add --no-cache apache2 apache2-ssl apache2-utils apache2-webdav apache2-ctl mod_dav_svn &&\
 	apk add --no-cache subversion &&\
 	apk add --no-cache wget unzip php7 php7-apache2 php7-session php7-json php7-ldap &&\
 	apk add --no-cache php7-xml &&\	

--- a/dav_svn.conf
+++ b/dav_svn.conf
@@ -8,6 +8,5 @@ LoadModule authz_svn_module /usr/lib/apache2/mod_authz_svn.so
      AuthType Basic
      AuthName "Subversion Repository"
      AuthUserFile /etc/subversion/passwd
-     AuthzSVNAccessFile /etc/subversion/subversion-access-control
      Require valid-user
   </Location>


### PR DESCRIPTION
This adds https to the existing support for the http and svn protocols. It also upgrades the alpine-base image to 3.3.0 which has the side effect of including a later version of the svn server 1.12.2. 
This may require a serverside repo upgrade (svnadmin upgrade) but svn clients built with 1.9 can connect. 